### PR TITLE
Return JSON-wrapped render response

### DIFF
--- a/alephant-publisher-queue.gemspec
+++ b/alephant-publisher-queue.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'alephant-cache'
   spec.add_runtime_dependency 'alephant-logger'
   spec.add_runtime_dependency 'alephant-lookup'
-  spec.add_runtime_dependency 'alephant-renderer', '~> 0.1.0'
+  spec.add_runtime_dependency 'alephant-renderer', '~> 1'
 end

--- a/lib/alephant/publisher/queue/writer.rb
+++ b/lib/alephant/publisher/queue/writer.rb
@@ -6,6 +6,7 @@ require 'alephant/logger'
 require 'alephant/sequencer'
 require 'alephant/support/parser'
 require 'alephant/renderer'
+require "alephant/renderer/response"
 
 module Alephant
   module Publisher
@@ -53,8 +54,12 @@ module Alephant
 
         def store(id, view, location)
           logger.info "Publisher::Queue::Writer#store: location '#{location}', message.id '#{message.id}'"
-          cache.put(location, view.render, view.content_type, :msg_id => message.id)
+          cache.put(location, json_response(view.render), view.content_type, :msg_id => message.id)
           lookup.write(id, options, seq_id, location)
+        end
+
+        def json_response(content)
+          Alephant::Renderer::Response.new(content).to_json
         end
 
         def location_for(id)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,4 +2,5 @@ require 'pry'
 
 require 'aws-sdk'
 require 'alephant/publisher/queue'
+require "alephant/renderer/response"
 


### PR DESCRIPTION
Wrap `view.render` in a `Alephant::Renderer::Response`, and store it in a JSON representation