### PR TITLE
Update to latest logger

### DIFF
--- a/alephant-publisher-queue.gemspec
+++ b/alephant-publisher-queue.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'alephant-support'
   spec.add_runtime_dependency 'alephant-sequencer'
   spec.add_runtime_dependency 'alephant-cache'
-  spec.add_runtime_dependency 'alephant-logger'
+  spec.add_runtime_dependency 'alephant-logger', "1.2.0"
   spec.add_runtime_dependency 'alephant-lookup'
   spec.add_runtime_dependency 'alephant-renderer'
 end

--- a/lib/alephant/publisher/queue/options.rb
+++ b/lib/alephant/publisher/queue/options.rb
@@ -49,10 +49,20 @@ module Alephant
             validate type, opts
             instance.merge! opts
           rescue Exception => e
-            logger.metric(:name => "PublisherQueueOptionsInvalidKeySpecified", :unit => "Count", :value => 1)
+            logger.metric("PublisherQueueOptionsInvalidKeySpecified", opts)
             logger.error "Publisher::Queue::Options#validate: '#{e.message}'"
             puts e.message
           end
+        end
+
+        def opts
+          {
+            :dimensions => {
+              :module   => "AlephantPublisherQueue",
+              :class    => "Options",
+              :function => "execute"
+            }
+          }
         end
 
         def validate(type, opts)

--- a/lib/alephant/publisher/queue/sqs_helper/archiver.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/archiver.rb
@@ -24,13 +24,28 @@ module Alephant
 
           def async_store(m)
             Thread.new { store(m) }
-            logger.metric(:name => "PublisherQueueSQSHelperAsynchronouslyArchivedData", :unit => "Count", :value => 1)
+            logger.metric(
+              "AsynchronouslyArchivedData",
+              opts[:dimensions].merge(:function => "async_store")
+            )
           end
 
           def store(m)
-            logger.metric(:name => "PublisherQueueSQSHelperSynchronouslyArchivedData", :unit => "Count", :value => 1)
+            logger.metric(
+              "SynchronouslyArchivedData",
+               opts[:dimensions].merge(:function => "store")
+            )
             logger.info "Publisher::Queue::SQSHelper::Archiver#store: '#{m.body}' at 'archive/#{date_key}/#{m.id}'"
             cache.put("archive/#{date_key}/#{m.id}", m.body, meta_for(m))
+          end
+
+          def opts
+            {
+              :dimensions => {
+                :module   => "AlephantPublisherQueueSQSHelper",
+                :class    => "Archiver"
+              }
+            }
           end
 
           def date_key

--- a/lib/alephant/publisher/queue/sqs_helper/queue.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/queue.rb
@@ -29,7 +29,10 @@ module Alephant
           private
 
           def process(m)
-            logger.metric(:name => "PublisherQueueSQSHelperMessagesReceived", :unit => "Count", :value => 1)
+            logger.metric(
+              "MessagesReceived",
+              opts[:dimensions].merge(:function => "process")
+            )
             logger.info("Queue#message: received #{m.id}")
             archive m
           end
@@ -37,7 +40,10 @@ module Alephant
           def archive(m)
             archiver.see(m) unless archiver.nil?
           rescue StandardError => e
-            logger.metric(:name => "PublisherQueueSQSHelperArchiveFailed", :unit => "Count", :value => 1)
+            logger.metric(
+              "ArchiveFailed",
+              opts[:dimensions].merge(:function => "archive")
+            )
             logger.warn("Queue#archive: archive failed (#{e.message})");
           end
 
@@ -46,6 +52,15 @@ module Alephant
               :visibility_timeout => timeout,
               :wait_time_seconds  => wait_time
             })
+          end
+
+          def opts
+            {
+              :dimensions => {
+                :module   => "PublisherQueueSQSHelper",
+                :class    => "Queue"
+              }
+            }
           end
         end
       end


### PR DESCRIPTION
## Problem

The Alephant Publisher Queue is used by Newbeat which is using an updated CloudWatch logger (the CloudWatch logger now has an updated interface). 

## Solution

We need to modify Alephant Publisher Queue to use the latest Alephant Logger (as that's what the updated Alephant CloudWatch Logger uses). Then update the `metric` calls to match the new interface.

## Release Plan

I believe this will be a patch release rather than a minor or major (as we're modifying code to fix some other library that has changed).