### PR TITLE
Remove Dimensions

### DIFF
--- a/lib/alephant/publisher/queue/options.rb
+++ b/lib/alephant/publisher/queue/options.rb
@@ -49,20 +49,10 @@ module Alephant
             validate type, opts
             instance.merge! opts
           rescue Exception => e
-            logger.metric("PublisherQueueOptionsInvalidKeySpecified", opts)
+            logger.metric("QueueOptionsInvalidKeySpecified")
             logger.error "Publisher::Queue::Options#validate: '#{e.message}'"
             puts e.message
           end
-        end
-
-        def opts
-          {
-            :dimensions => {
-              :module   => "AlephantPublisherQueue",
-              :class    => "Options",
-              :function => "execute"
-            }
-          }
         end
 
         def validate(type, opts)

--- a/lib/alephant/publisher/queue/options.rb
+++ b/lib/alephant/publisher/queue/options.rb
@@ -49,7 +49,7 @@ module Alephant
             validate type, opts
             instance.merge! opts
           rescue Exception => e
-            logger.metric("QueueOptionsInvalidKeySpecified")
+            logger.metric "QueueOptionsInvalidKeySpecified"
             logger.error "Publisher::Queue::Options#validate: '#{e.message}'"
             puts e.message
           end

--- a/lib/alephant/publisher/queue/sqs_helper/archiver.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/archiver.rb
@@ -24,11 +24,11 @@ module Alephant
 
           def async_store(m)
             Thread.new { store(m) }
-            logger.metric("AsynchronouslyArchivedData")
+            logger.metric "AsynchronouslyArchivedData"
           end
 
           def store(m)
-            logger.metric("SynchronouslyArchivedData")
+            logger.metric "SynchronouslyArchivedData"
             logger.info "Publisher::Queue::SQSHelper::Archiver#store: '#{m.body}' at 'archive/#{date_key}/#{m.id}'"
             cache.put("archive/#{date_key}/#{m.id}", m.body, meta_for(m))
           end

--- a/lib/alephant/publisher/queue/sqs_helper/archiver.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/archiver.rb
@@ -24,28 +24,13 @@ module Alephant
 
           def async_store(m)
             Thread.new { store(m) }
-            logger.metric(
-              "AsynchronouslyArchivedData",
-              opts[:dimensions].merge(:function => "async_store")
-            )
+            logger.metric("AsynchronouslyArchivedData")
           end
 
           def store(m)
-            logger.metric(
-              "SynchronouslyArchivedData",
-               opts[:dimensions].merge(:function => "store")
-            )
+            logger.metric("SynchronouslyArchivedData")
             logger.info "Publisher::Queue::SQSHelper::Archiver#store: '#{m.body}' at 'archive/#{date_key}/#{m.id}'"
             cache.put("archive/#{date_key}/#{m.id}", m.body, meta_for(m))
-          end
-
-          def opts
-            {
-              :dimensions => {
-                :module   => "AlephantPublisherQueueSQSHelper",
-                :class    => "Archiver"
-              }
-            }
           end
 
           def date_key

--- a/lib/alephant/publisher/queue/sqs_helper/queue.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/queue.rb
@@ -29,7 +29,7 @@ module Alephant
           private
 
           def process(m)
-            logger.metric("MessagesReceived")
+            logger.metric "MessagesReceived"
             logger.info("Queue#message: received #{m.id}")
             archive m
           end
@@ -37,7 +37,7 @@ module Alephant
           def archive(m)
             archiver.see(m) unless archiver.nil?
           rescue StandardError => e
-            logger.metric("ArchiveFailed")
+            logger.metric "ArchiveFailed"
             logger.warn("Queue#archive: archive failed (#{e.message})");
           end
 

--- a/lib/alephant/publisher/queue/sqs_helper/queue.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/queue.rb
@@ -29,10 +29,7 @@ module Alephant
           private
 
           def process(m)
-            logger.metric(
-              "MessagesReceived",
-              opts[:dimensions].merge(:function => "process")
-            )
+            logger.metric("MessagesReceived")
             logger.info("Queue#message: received #{m.id}")
             archive m
           end
@@ -40,10 +37,7 @@ module Alephant
           def archive(m)
             archiver.see(m) unless archiver.nil?
           rescue StandardError => e
-            logger.metric(
-              "ArchiveFailed",
-              opts[:dimensions].merge(:function => "archive")
-            )
+            logger.metric("ArchiveFailed")
             logger.warn("Queue#archive: archive failed (#{e.message})");
           end
 
@@ -52,15 +46,6 @@ module Alephant
               :visibility_timeout => timeout,
               :wait_time_seconds  => wait_time
             })
-          end
-
-          def opts
-            {
-              :dimensions => {
-                :module   => "PublisherQueueSQSHelper",
-                :class    => "Queue"
-              }
-            }
           end
         end
       end


### PR DESCRIPTION
## Problem

Alarms aren't firing, due to dimensions associated with the alarm

## Solution

Remove the dimensions from metric calls so they will work with the latest version of Alephant CloudWatch Logger (`2.0.2`)

## Gem Release

This should be a patch release to `1.3.6`