### PR TITLE
Write batch record for all renderer applications

### DIFF
--- a/lib/alephant/publisher/queue/writer.rb
+++ b/lib/alephant/publisher/queue/writer.rb
@@ -35,12 +35,12 @@ module Alephant
         end
 
         def run!
-          batch.validate(message, &perform)
+          seq_for(config[:renderer_id]).validate(message, &process_components)
         end
 
         protected
 
-        def perform
+        def process_components
           Proc.new { views.each { |id, view| write(id, view) } }
         end
 
@@ -85,10 +85,6 @@ module Alephant
 
         def location_for(id)
           "#{config[:renderer_id]}/#{id}/#{opt_hash}/#{seq_id}"
-        end
-
-        def batch
-          seq_for(config[:renderer_id])
         end
 
         def seq_for(id)

--- a/lib/alephant/publisher/queue/writer.rb
+++ b/lib/alephant/publisher/queue/writer.rb
@@ -35,7 +35,7 @@ module Alephant
         end
 
         def run!
-          batch? ? batch.validate(message, &perform) : perform.call
+          batch.validate(message, &perform)
         end
 
         protected
@@ -88,11 +88,7 @@ module Alephant
         end
 
         def batch
-          @batch ||= (views.count > 1) ? seq_for(config[:renderer_id]) : nil
-        end
-
-        def batch?
-          !batch.nil?
+          seq_for(config[:renderer_id])
         end
 
         def seq_for(id)


### PR DESCRIPTION
## Problem
At the moment, we only write a batch record to DynamoDB for renderer applications which have more than one component. This means the PAL can't request this component using a batch request.

## Solution
It seems a better approach, if we write a batch record for all renderer applications, then the PAL (or whatever is going to request the components) can decide if it is going to request them in batch or not.

https://jira.dev.bbc.co.uk/browse/CONNPOL-2834

![](https://media.giphy.com/media/IwTWTsUzmIicM/giphy.gif)