### PR TITLE
Log only Newsbeat URIs

### DIFF
--- a/lib/alephant/publisher/queue/sqs_helper/archiver.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/archiver.rb
@@ -39,13 +39,27 @@ module Alephant
           end
 
           def store(message)
+            msg_body = body_for(message)
             store_item(message).tap do
               logger.info(
                 "event"       => "MessageStored",
-                "messageBody" => body_for(message),
+                "messageBody" => msg_body,
                 "method"      => "#{self.class}#store"
-              )
+              ) if newsbeat_uri? msg_body
             end
+          end
+
+          def newsbeat_uri?(msg_body)
+            jsb = JSON.parse(msg_body)
+            msg = JSON.parse(jsb["Message"]) if jsb["Message"]
+
+            true if verify_message_content msg
+          rescue JSON::ParserError
+            false
+          end
+
+          def verify_message_content(msg)
+            !msg.nil? && msg["uri"] && msg["uri"] =~ /content\/asset\/newsbeat/
           end
 
           def store_item(message)
@@ -68,7 +82,7 @@ module Alephant
           end
 
           def body_for(message)
-            log_message_body ? message.body : "No message body available"
+            log_message_body ? message.body : '{ "Message": "No message body available" }'
           end
 
           def date_key

--- a/lib/alephant/publisher/queue/sqs_helper/archiver.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/archiver.rb
@@ -50,11 +50,11 @@ module Alephant
           end
 
           def newsbeat_uri?(msg_body)
-            jsb = JSON.parse(msg_body)
-            msg = JSON.parse(jsb["Message"]) if jsb["Message"]
+            jsb = ::JSON.parse(msg_body)
+            msg = ::JSON.parse(jsb["Message"]) if jsb["Message"]
 
             true if verify_message_content msg
-          rescue JSON::ParserError
+          rescue ::JSON::ParserError
             false
           end
 

--- a/spec/archiver_spec.rb
+++ b/spec/archiver_spec.rb
@@ -1,15 +1,17 @@
 require "spec_helper"
 
 describe Alephant::Publisher::Queue::SQSHelper::Archiver do
-  let (:cache) { instance_double("Alephant::Cache", :put => nil) }
-  let (:queue) { instance_double("AWS::SQS::Queue", :url => nil) }
+  let (:cache)    { instance_double("Alephant::Cache", :put => nil) }
+  let (:queue)    { instance_double("AWS::SQS::Queue", :url => nil) }
+  let (:msg_body) {{ :Message => JSON.generate(msg_uri) }}
+  let (:msg_uri)  {{ :uri => "/content/asset/newsbeat" }}
   let (:message) do
     instance_double(
       "AWS::SQS::ReceivedMessage",
       :id    => "id",
-      :body  => "bar_baz",
       :md5   => "qux",
-      :queue => queue
+      :queue => queue,
+      :body  => JSON.generate(msg_body)
     )
   end
 


### PR DESCRIPTION
![](http://45.media.tumblr.com/fc7adef3e742e99ba89698a6106d4d4c/tumblr_nxd183Oi6G1sq1n6uo1_540.gif)
*^ Steve when he sees no useful logs*

## Problem

Stop Newsbeat or Alephant logging notifications for sites it doesn't care about

https://jira.dev.bbc.co.uk/browse/RESFRAME-580

## Notes

A similar change would need to be applied to both Alephant Publisher Queue and the BBC-Content-Services gem