### PR TITLE
Swap concrete implementation with injected behaviour

### DIFF
--- a/lib/alephant/publisher/queue/options.rb
+++ b/lib/alephant/publisher/queue/options.rb
@@ -17,6 +17,7 @@ module Alephant
           :visibility_timeout,
           :aws_account_id,
           :log_archive_message,
+          :log_validator,
           :async_store
         ]
 


### PR DESCRIPTION
![](http://media.riffsy.com/images/fe943c58f1f823b8251c14953574f926/raw)

## Problem

BBC specific use case was hardcoded into this gem

## Solution

Inject the behaviour instead

## Note

The subsequent consumers of this gem need to pass through a proc/lambda which executes the specific behaviour required:

```rb
Alephant::Publisher::Queue.create(options, nil).run!

def options
  Alephant::Publisher::Queue::Options.new.tap do |opts|                                                                                            
    opts.add_queue(
      :log_validator  => -> message_body { valid? message_body }
    ) 
  end
end

def valid?(data)
  # return true or false depending on your validation logic
  # e.g. you could extract a key from the message and validate its value
  # so effectively this method can be named anything you like (e.g. valid_uri?)
end
```