### PR TITLE
Update for AWS SDV V2+

### DIFF
--- a/lib/alephant/publisher/queue/sqs_helper/archiver.rb
+++ b/lib/alephant/publisher/queue/sqs_helper/archiver.rb
@@ -52,7 +52,7 @@ module Alephant
 
           def store_item(message)
             storage.put(
-              storage_key(message.id),
+              storage_key(message.message_id),
               message.body,
               meta_for(message)
             )

--- a/lib/alephant/publisher/queue/version.rb
+++ b/lib/alephant/publisher/queue/version.rb
@@ -1,7 +1,7 @@
 module Alephant
   module Publisher
     module Queue
-      VERSION = '2.6.0'.freeze
+      VERSION = '2.6.1'.freeze
     end
   end
 end

--- a/lib/alephant/publisher/queue/writer.rb
+++ b/lib/alephant/publisher/queue/writer.rb
@@ -62,7 +62,7 @@ module Alephant
               component,
               view,
               location_for(component),
-              :msg_id => message.id
+              :msg_id => message.message_id
             )
           end.tap do
             logger.info(
@@ -101,7 +101,7 @@ module Alephant
               "render"         => render.force_encoding("utf-8"),
               "contentType"    => view.content_type,
               "storageOptions" => storage_opts,
-              "messageId"      => message.id,
+              "messageId"      => message.message_id,
               "method"         => "#{self.class}#store"
             )
           end

--- a/spec/alephant/publisher/queue/sqs_helper/archiver_spec.rb
+++ b/spec/alephant/publisher/queue/sqs_helper/archiver_spec.rb
@@ -36,7 +36,7 @@ describe Alephant::Publisher::Queue::SQSHelper::Archiver do
         expect(storage).to receive(:put).with(
           "archive/#{time_now.strftime('%d-%m-%Y_%H')}/id",
           message.body,
-          :id        => message.id,
+          :id        => message.message_id,
           :md5       => message.md5,
           :logged_at => time_now.to_s,
           :queue     => message.queue.url


### PR DESCRIPTION
AWS SDK v2+ replaced AWS::SQS::Message.id with AWS::SQS::Message.message_id This PR reflects that change